### PR TITLE
fix: article schema by removing validator for source

### DIFF
--- a/models/article.js
+++ b/models/article.js
@@ -23,10 +23,6 @@ const articleSchema = new mongoose.Schema({
   source: {
     type: String,
     required: true,
-    validate: {
-      validator: (v) => validator.isURL(v),
-      message: 'The \'link\' field must have an email address',
-    },
   },
   link: {
     type: String,


### PR DESCRIPTION
The [news api](https://newsapi.org/) does not use a URL for source data (the value should just be a simple a string) 
<details open>
<summary>See news API format</summary>
<br>
<img width="759" alt="Screen Shot 2021-06-02 at 10 50 38 AM" src="https://user-images.githubusercontent.com/34360644/120502382-61e47080-c390-11eb-9e8d-b233e5c8ad18.png">
</details>
Fixes status 500 error when sending a request to 'save' an article